### PR TITLE
Update/isometry cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,10 @@ project(descartes_opw_model)
 add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
-  descartes_moveit
-  opw_kinematics
+  descartes_moveit  
 )
+
+find_package(opw_kinematics)
 
 catkin_package(
   INCLUDE_DIRS
@@ -14,8 +15,7 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS
-    descartes_moveit
-    opw_kinematics
+    descartes_moveit    
 )
 
 ###########
@@ -25,6 +25,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${opw_kinematics_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(opw_kinematics)
 catkin_package(
   INCLUDE_DIRS
     include
+    ${opw_kinematics_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS

--- a/package.xml
+++ b/package.xml
@@ -10,12 +10,10 @@
   <license>GPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>descartes_moveit</build_depend>
-  <build_depend>opw_kinematics</build_depend>
-  <build_export_depend>descartes_moveit</build_export_depend>
-  <build_export_depend>opw_kinematics</build_export_depend>
+  <build_depend>descartes_moveit</build_depend> 
+  <build_export_depend>descartes_moveit</build_export_depend>  
   <exec_depend>descartes_moveit</exec_depend>
-  <exec_depend>opw_kinematics</exec_depend>
+  
 
 
   <export>


### PR DESCRIPTION
opw_kinematics isn't a catkin package anymore.  Change it to use regular find_package and remove it from package.xml.